### PR TITLE
Update to the file for the 3.0.1 Nozzle release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -3,7 +3,7 @@ title: VMware Tanzu Observability by Wavefront Nozzle
 owner: Partners
 ---
 
-<strong>Page last updated: March 5, 2021</strong>
+<strong>Page last updated: May 19, 2021</strong>
 
 This documentation describes the VMware Tanzu Observability by Wavefront Nozzle integration for VMware Tanzu Application Service for VMs (TAS for VMs).
 Use this integration to monitor the health and performance of your VMware Tanzu Application Service for VMs (TAS for VMs) deployment and apps by using [Tanzu Observability by Wavefront](https://docs.wavefront.com).

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -59,23 +59,23 @@ The following table provides version and version-support information about VMwar
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v3.0.0</td>
+        <td>v3.0.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>February 5, 2021</td>
+        <td>May 19, 2021</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>VMware Tanzu Observability by Wavefront Nozzle v1.3.0, VMware Tanzu Observability by Wavefront Proxy v9.2, and VMware Tanzu Observability by Wavefront Service Broker v0.9.5</td>
+        <td>VMware Tanzu Observability by Wavefront Nozzle v1.3.1, VMware Tanzu Observability by Wavefront Proxy v9.2, and VMware Tanzu Observability by Wavefront Service Broker v0.9.5</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.5.x, v2.6.x, v2.7.x, v2.8.x, v2.9.x and v2.10.x</td>
+        <td>v2.5.x, v2.6.x, v2.7.x, v2.8.x, v2.9.x, v2.10.x, and v2.11.x</td>
     </tr>
     <tr>
         <td>Compatible VMware Tanzu Application Service for VMs version(s)</td>
-        <td>v2.5.x, v2.6.x, v2.7.x, v2.8.x, v2.9.x and v2.10.x</td>
+        <td>v2.5.x, v2.6.x, v2.7.x, v2.8.x, v2.9.x, v2.10.x, and v2.11.x</td>
     </tr>
     <tr>
        <td>BOSH stemcell version</td>


### PR DESCRIPTION
Here's what I've changed:

- Tile version: 3.0.1
- Release Date: May 19, 2021
- Changed the Wavefront Nozzle v1.3.0 to Wavefront Nozzle v1.3.1
- Added v2.11.x to Ops Manager support 
- Added v2.11.x to Tanzu Application Service for VMs version(s)