### PR TITLE
Ops Manager 2.11 is not released yet

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -71,7 +71,7 @@ The following table provides version and version-support information about VMwar
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.5.x, v2.6.x, v2.7.x, v2.8.x, v2.9.x, v2.10.x, and v2.11.x</td>
+        <td>v2.5.x, v2.6.x, v2.7.x, v2.8.x, v2.9.x, and v2.10.x</td>
     </tr>
     <tr>
         <td>Compatible VMware Tanzu Application Service for VMs version(s)</td>


### PR DESCRIPTION
Just got informed by the eng. team about that, so removing the v2.11.x Ops Manager version