### PR TITLE
3.x

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -12,6 +12,15 @@ These are release notes for VMware Tanzu Observability by Wavefront Nozzle.
 **Release Date:** December 15, 2021
 
 * Follow up fix to completely close the loop on prior vulnerability.
+* For releases prior to 3.0.4, there is a workaround available to addres Log4J vulnerabilities without upgrading.
+  * Apache foundation gives this guidance:
+
+    ```
+    In any release other than 2.16.0, you may remove the JndiLookup class from the classpath: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+    ```
+
+  * To execute this against our tile, you'll be using a slightly different command, the class file to be removed is built into `wavefront-proxy.jar`, so you would change the command to `zip -q -d wavefront-proxy.jar org/apache/logging/log4j/core/lookup/JndiLookup.class`
+  * You'll also need to get access to the .jar inside of the .pivotal. The path to the .jar inside of the .pivotal file is `releases/wavefront-proxy-${VERSION}.tgz/packages/wavefront_proxy_pkg.tgz/wavefront-proxy.jar`
 
 ##<a id="3-0-3"></a> v3.0.3
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -2,7 +2,6 @@
 title: Release Notes for VMware Tanzu Observability by Wavefront Nozzle
 owner: Partners
 ---
-zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 <strong>Page last updated: December 17, 2021</strong>
 
 These are release notes for VMware Tanzu Observability by Wavefront Nozzle.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -2,8 +2,8 @@
 title: Release Notes for VMware Tanzu Observability by Wavefront Nozzle
 owner: Partners
 ---
-
-<strong>Page last updated: December 15, 2021</strong>
+zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+<strong>Page last updated: December 17, 2021</strong>
 
 These are release notes for VMware Tanzu Observability by Wavefront Nozzle.
 


### PR DESCRIPTION
We've been asked to publish information on the workaround released by Log4J for users who can't pull in the official fix just yet. The release notes for the fixed version seemed like a good place to include that.